### PR TITLE
fix: do not generate docs if ctags were not generated

### DIFF
--- a/cmake/Documentation.cmake
+++ b/cmake/Documentation.cmake
@@ -1,5 +1,5 @@
 find_package(Doxygen)
-if(DOXYGEN_FOUND)
+if(DOXYGEN_FOUND AND TARGET tags)
 	if(GIT_REPO_FOUND)
 		git_authors(GIT_AUTHORS AUTHOR_LIST)
 	else()


### PR DESCRIPTION
The Doxygen configuration assumes there is a tags file generated,
which does not happen if CTags/CScope are not present. This failed
the build if doxygen was installed and one of them was not.